### PR TITLE
Fix for Postgres

### DIFF
--- a/components/CommentsHelper.php
+++ b/components/CommentsHelper.php
@@ -44,7 +44,7 @@ class CommentsHelper
             'dependency' => [
                 'class' => 'yii\caching\DbDependency',
                 'sql' => "SELECT COUNT(*) FROM {$tableName} "
-                    . "WHERE `model` = '{$model}' AND `model_id` = '{$model_id}'",
+                    . "WHERE {{model}} = '{$model}' AND {{model_id}} = '{$model_id}'",
             ]
         ];
     }


### PR DESCRIPTION
PDOException: SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exists: ` character varying

SELECT COUNT(*) FROM "comment" WHERE model = 'yeesoft\post