### PR TITLE
Fix Database Exception

### DIFF
--- a/components/CommentsHelper.php
+++ b/components/CommentsHelper.php
@@ -44,7 +44,7 @@ class CommentsHelper
             'dependency' => [
                 'class' => 'yii\caching\DbDependency',
                 'sql' => "SELECT COUNT(*) FROM {$tableName} "
-                    . "WHERE `model` = '{$model}' AND `model_id` = '{$model_id}'",
+                    . "WHERE {{%model}} = '{$model}' AND {{%model_id}} = '{$model_id}'",
             ]
         ];
     }


### PR DESCRIPTION
Fix for quotes Postgres this error:
SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: ` character varying
LINE 1: SELECT COUNT(*) FROM "comment" WHERE `model` = 'Model' AND...
^
HINT: No operator matches the given name and argument type. You might need to add an explicit type cast.
The SQL being executed was: SELECT COUNT(*) FROM "comment" WHERE `model` = 'Model' AND `model_id` = '3'